### PR TITLE
Add CI for Unit Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET 7
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+
+    - name: Restore Dependencies
+      run: dotnet restore src
+
+    - name: Build
+      run: dotnet build src --configuration Release --no-restore
+
+    - name: Unit Test
+      run: |
+        cd ./tests/Equaliser.UnitTests/
+        dotnet test --no-restore /e:CollectCoverage=true /e:CoverletOutput=/home/runner/work/equaliser/equaliser/ /e:CoverletOutputFormat=opencover

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Unit Test
       run: |
         cd ./tests/Equaliser.UnitTests/
-        dotnet test --no-restore -e:CollectCoverage=true -e:CoverletOutput=/home/runner/work/equaliser/equaliser/ -e:CoverletOutputFormat=opencover
+        dotnet test --no-restore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Unit Test
       run: |
         cd ./tests/Equaliser.UnitTests/
-        dotnet test --no-restore /e:CollectCoverage=true /e:CoverletOutput=/home/runner/work/equaliser/equaliser/ /e:CoverletOutputFormat=opencover
+        dotnet test --no-restore -e:CollectCoverage=true -e:CoverletOutput=/home/runner/work/equaliser/equaliser/ -e:CoverletOutputFormat=opencover

--- a/tests/Equaliser.UnitTests/Equaliser.UnitTests.csproj
+++ b/tests/Equaliser.UnitTests/Equaliser.UnitTests.csproj
@@ -1,17 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <Nullable>enable</Nullable>
-
-        <IsPackable>false</IsPackable>
+      <TargetFramework>net7.0</TargetFramework>
+      <Nullable>enable</Nullable>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="NUnit" Version="3.13.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-        <PackageReference Include="coverlet.collector" Version="3.1.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+      <PackageReference Include="NUnit" Version="3.13.3" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+      <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Adds a simple GitHub Action for running unit tests in CI. 

This Action will run unit tests against any pushed branch, as well as on pull requests against `master` (the repository's current primary branch). Initial successful Action run can be viewed on the fork branch [here](https://github.com/wbaldoumas/Equaliser/actions/runs/3716232383/jobs/6302329694).

Additional changes: updated all package dependencies to latest within `Equaliser.UnitTests`.