### PR TITLE
Testing Adjustments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Setup .NET 7
+    - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,9 @@ jobs:
     - name: Setup .NET 7
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: |
+          6.0.x
+          7.0.x
 
     - name: Restore Dependencies
       run: dotnet restore src

--- a/tests/Equaliser.UnitTests/Equaliser.UnitTests.csproj
+++ b/tests/Equaliser.UnitTests/Equaliser.UnitTests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>net7.0</TargetFramework>
+      <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
       <Nullable>enable</Nullable>
       <IsPackable>false</IsPackable>
+      <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTest.cs
+++ b/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTest.cs
@@ -1,11 +1,11 @@
-using System;
-
 namespace Equaliser.UnitTests.TestInputs;
 
 public class ObjectUnderTest : IEquatable<ObjectUnderTest>
 {
     public int Property1 { get; set; }
+
     public string Property2 { get; set; }
+
     public ChildObject Property3 { get; set; }
     
     public bool Equals(ObjectUnderTest? other)

--- a/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithBrokenEqualityMethod.cs
+++ b/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithBrokenEqualityMethod.cs
@@ -1,11 +1,11 @@
-using System;
-
 namespace Equaliser.UnitTests.TestInputs;
 
 public class ObjectUnderTestWithBrokenEqualityMethod : IEquatable<ObjectUnderTestWithBrokenEqualityMethod>
 {
     public int Property1 { get; set; }
+
     public string Property2 { get; set; }
+
     public ChildObject Property3 { get; set; }
     
     public bool Equals(ObjectUnderTestWithBrokenEqualityMethod other)

--- a/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithIgnoredPropertyWithAttribute.cs
+++ b/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithIgnoredPropertyWithAttribute.cs
@@ -1,4 +1,3 @@
-using System;
 using Equaliser.Attributes;
 
 namespace Equaliser.UnitTests.TestInputs;
@@ -6,8 +5,10 @@ namespace Equaliser.UnitTests.TestInputs;
 public class ObjectUnderTestWithIgnoredPropertyWithAttribute : IEquatable<ObjectUnderTestWithIgnoredPropertyWithAttribute>
 {
     public int Property1 { get; set; }
+
     [Ignore]
     public string Property2 { get; set; }
+
     public ChildObject Property3 { get; set; }
     
     public bool Equals(ObjectUnderTestWithIgnoredPropertyWithAttribute other)

--- a/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithIgnoredPropertyWithoutAttribute.cs
+++ b/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithIgnoredPropertyWithoutAttribute.cs
@@ -1,12 +1,11 @@
-using System;
-using Equaliser.Attributes;
-
 namespace Equaliser.UnitTests.TestInputs;
 
 public class ObjectUnderTestWithIgnoredPropertyWithoutAttribute : IEquatable<ObjectUnderTestWithIgnoredPropertyWithoutAttribute>
 {
     public int Property1 { get; set; }
+
     public string Property2 { get; set; }
+
     public ChildObject Property3 { get; set; }
     
     public bool Equals(ObjectUnderTestWithIgnoredPropertyWithoutAttribute other)

--- a/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithReferencePropertyWithAttribute.cs
+++ b/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithReferencePropertyWithAttribute.cs
@@ -1,4 +1,3 @@
-using System;
 using Equaliser.Attributes;
 
 namespace Equaliser.UnitTests.TestInputs;
@@ -6,7 +5,9 @@ namespace Equaliser.UnitTests.TestInputs;
 public class ObjectUnderTestWithReferencePropertyWithAttribute : IEquatable<ObjectUnderTestWithReferencePropertyWithAttribute>
 {
     public int Property1 { get; set; }
+
     public string Property2 { get; set; }
+
     [CompareByReference]
     public ChildObject Property3 { get; set; }
     

--- a/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithReferencePropertyWithoutAttribute.cs
+++ b/tests/Equaliser.UnitTests/TestInputs/ObjectUnderTestWithReferencePropertyWithoutAttribute.cs
@@ -1,11 +1,11 @@
-using System;
-
 namespace Equaliser.UnitTests.TestInputs;
 
 public class ObjectUnderTestWithReferencePropertyWithoutAttribute : IEquatable<ObjectUnderTestWithReferencePropertyWithoutAttribute>
 {
     public int Property1 { get; set; }
+
     public string Property2 { get; set; }
+
     public ChildObject Property3 { get; set; }
     
     public bool Equals(ObjectUnderTestWithReferencePropertyWithoutAttribute other)

--- a/tests/Equaliser.UnitTests/TestsForAggregateEqualityTests.cs
+++ b/tests/Equaliser.UnitTests/TestsForAggregateEqualityTests.cs
@@ -1,6 +1,0 @@
-namespace Equaliser.UnitTests;
-
-public class TestsForNamespaceEqualityTests
-{
-    
-}

--- a/tests/Equaliser.UnitTests/TestsForEqualityTests.cs
+++ b/tests/Equaliser.UnitTests/TestsForEqualityTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Equaliser.Tests;
 using Equaliser.UnitTests.TestInputs;
 using NUnit.Framework;


### PR DESCRIPTION
Adjust tests by:

- Test against multiple target frameworks
- Update CI to test against multiple target frameworks
- enable `ImplicitUsings` and remove unused `using` statements
- Formatting cleanup
- Delete unused `TestsForAggregateEqualityTests`